### PR TITLE
Changes to improve the experience for short requests

### DIFF
--- a/bin/plackbench
+++ b/bin/plackbench
@@ -82,6 +82,8 @@ sub _report {
     $opts->{precision} //= 3;
     my $time = "%8.$opts->{precision}f";
 
+    printf "Rate (requests per second): %.2f\n\n", $stats->rate;
+
     print "Request times (seconds):\n";
     printf( "%8s %8s %8s %8s %8s\n", 'min', 'mean', 'sd', 'median', 'max' );
     printf( "$time $time $time $time $time\n\n",

--- a/bin/plackbench
+++ b/bin/plackbench
@@ -29,7 +29,7 @@ if ($opts->{fixup_files}) {
 }
 
 my $stats = $bench->run();
-_report($stats);
+_report($stats, $opts);
 
 exit 0;
 
@@ -46,6 +46,7 @@ sub _parse_argv {
         'post=s' => \$opts{post_data},
         'e=s'    => \$opts{fixup},
         'f=s'    => \$opts{fixup_files},
+        'p=i'    => \$opts{precision},
     );
 
     ( $opts{psgi_path}, $opts{uri} ) = @{$argv};
@@ -76,16 +77,20 @@ sub _post_data {
 
 sub _report {
     my $stats = shift;
+    my $opts = shift;
+
+    $opts->{precision} //= 3;
+    my $time = "%8.$opts->{precision}f";
 
     print "Request times (seconds):\n";
     printf( "%8s %8s %8s %8s %8s\n", 'min', 'mean', 'sd', 'median', 'max' );
-    printf( "%8.3f %8.3f %8.3f %8.3f %8.3f\n\n",
+    printf( "$time $time $time $time $time\n\n",
         $stats->min(), $stats->mean(), $stats->standard_deviation(), $stats->median(), $stats->max() );
 
     print "Percentage of requests within a certain time (seconds):\n";
     for my $percent ( 50, 66, 75, 80, 90, 95, 98, 99, 100 ) {
         my $value = $stats->percentile( $percent );
-        printf( "%4d%% %8.3f\n", $percent, $value );
+        printf( "%4d%% $time\n", $percent, $value );
     }
 }
 
@@ -170,6 +175,10 @@ A simple example:
 The file can contain any valid Perl code, but the last statement in the file
 must be a subroutine reference.
 
+=item -p <precision>
+
+The number of decimal places in times included in the report. Defaults to 3.
+
 =back
 
 =head1 Using with L<Devel::NYTProf>
@@ -203,3 +212,4 @@ This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.
 
 =cut
+

--- a/lib/App/plackbench.pm
+++ b/lib/App/plackbench.pm
@@ -7,7 +7,7 @@ use v5.10;
 
 use HTTP::Request qw();
 use List::Util qw( reduce );
-use Plack::Test qw( test_psgi );
+use Plack::Test qw();
 use Plack::Util qw();
 use Scalar::Util qw( reftype );
 use Time::HiRes qw( gettimeofday tv_interval );
@@ -16,6 +16,7 @@ use App::plackbench::Stats;
 
 my %attributes = (
     app       => \&_build_app,
+    tester    => \&_build_tester,
     count     => 1,
     warm      => 0,
     fixup     => sub { [] },
@@ -69,6 +70,11 @@ sub new {
 sub _build_app {
     my $self = shift;
     return Plack::Util::load_psgi($self->psgi_path());
+}
+
+sub _build_tester {
+    my $self = shift;
+    return Plack::Test->create($self->app());
 }
 
 sub run {
@@ -170,14 +176,10 @@ sub add_fixup_from_file {
 sub _execute_request {
     my $self = shift;
     my $request = shift;
-
-    test_psgi $self->app(), sub {
-        my $cb       = shift;
-        my $response = $cb->($request);
-        if ( $response->is_error() ) {
-            die "Request failed: " . $response->decoded_content;
-        }
-    };
+    my $response = $self->tester->request($request);
+    if ( $response->is_error() ) {
+        die "Request failed: " . $response->decoded_content;
+    }
 
     return;
 }
@@ -212,6 +214,10 @@ Class for executing requests on a L<Plack> application and recording stats.
 =head2 app
 
 Defaults to a L<Plack> app loaded from L<psgi_path>, using L<Plack::Util/load_psgi>.
+
+=head2 tester
+
+Defaults to a L<Plack::Test> instance initialized with the app from L</app>.
 
 =head2 count
 
@@ -288,3 +294,4 @@ the same terms as the Perl 5 programming language system itself.
 =head1 SEE ALSO
 
 L<plackbench>, L<Plack>
+

--- a/lib/App/plackbench/Stats.pm
+++ b/lib/App/plackbench/Stats.pm
@@ -40,7 +40,7 @@ sub mean {
     my $self = shift;
 
     return unless $self->count();
-    return sum(@{$self}) / $self->count();
+    return $self->elapsed() / $self->count();
 }
 
 sub median {
@@ -96,6 +96,19 @@ sub percentile {
     return $self->[$n];
 }
 
+sub elapsed {
+    my $self = shift;
+
+    return sum(@$self) || 0;
+}
+
+sub rate {
+    my $self = shift;
+
+    return 0 unless $self->elapsed();
+    return $self->count() / $self->elapsed();
+}
+
 1;
 
 __END__
@@ -120,6 +133,14 @@ Inserts a number into the collection. The number will be inserted in order.
 =head2 count
 
 Returns the number of items in the collection.
+
+=head2 elapsed
+
+Returns the total time took waiting for the requests to complete.
+
+=head2 rate
+
+Returns the rate at which the requests were made (number of requests per second)
 
 =head2 mean
 
@@ -148,3 +169,4 @@ Returns the number at percentile C<$n>.
 =head2 SEE ALSO
 
 L<plackbench>
+

--- a/t/02_stats.t
+++ b/t/02_stats.t
@@ -15,6 +15,8 @@ subtest 'min'                => \&test_min;
 subtest 'max'                => \&test_max;
 subtest 'standard deviation' => \&test_standard_deviation;
 subtest 'percentile'         => \&test_percentile;
+subtest 'elapsed'            => \&test_elapsed;
+subtest 'rate'               => \&test_rate;
 
 done_testing();
 
@@ -123,4 +125,25 @@ sub test_percentile {
     return;
 }
 
+sub test_elapsed {
+    my $stats = App::plackbench::Stats->new(2, 4, 4, 4, 5, 5, 7, 9);
+    is( $stats->elapsed(), 40, 'elapsed() should return the total time' );
+
+    $stats = App::plackbench::Stats->new();
+    is( $stats->elapsed(), 0, 'elapsed() should return 0 for an empty list' );
+
+    return;
+}
+
+sub test_rate {
+    my $stats = App::plackbench::Stats->new(0.1, 0.2, 0.3, 0.1, 0.2, 0.1);
+    is( $stats->rate(), 6, 'rate() should return the number of requests per second' );
+
+    $stats = App::plackbench::Stats->new();
+    is( $stats->rate(), 0, 'rate() should return 0 for an empty list' );
+
+    return;
+}
+
 1;
+


### PR DESCRIPTION
Hello, thank you for writing plackbench - it is a useful tool. However, the bundled script currently does not contain useful output if requests take less than a milisecond.

This patch introduces a couple of minor changes which should help with this:
- makes it possible to specify the printed number of decimal places in the request times
- add `elapsed()` and `rate()` to stats, always show Rate (req/s) in the output
- add `tester()` to the main class, measure less overhead by simplifying how the requests are done

If you'd like, I could become a co-maintainer and do the releasing - my CPAN handle is `BRTASTIC`.